### PR TITLE
fix for tagged instances

### DIFF
--- a/bin/aws
+++ b/bin/aws
@@ -34,7 +34,7 @@ ec2_parse() {
       [[ $hostname == ec2* ]] && key="${edi[6]}.pem" type="${edi[8]}"
       [[ $hostname == ip* ]] && key="${edi[5]}.pem" type="${edi[7]}"
     elif [[ $header == TAG ]]; then
-      [[ $hostname && $key ]] && name="${edi[4]:-NONAME}"
+      [[ $hostname && $key ]] && [[ ${edi[3]} == "Name" ]] && name="${edi[4]:-NONAME}"
     elif [[ $header == RESERVATION ]]; then
       [[ $hostname && $key ]] && name='NONAME'
     fi


### PR DESCRIPTION
Tagging instances in EC2 caused the script to parse the wrong field for instance names, since it assumed the first tag listed by ec2-describe-instances was the name.
